### PR TITLE
feat: enable tls on grpc clients

### DIFF
--- a/go/clients/codehost.go
+++ b/go/clients/codehost.go
@@ -5,14 +5,16 @@
 package clients
 
 import (
+	"crypto/tls"
+
 	"github.com/reviewpad/api/go/services"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 func NewCodeHostClient(endpoint string) (services.HostClient, *grpc.ClientConn, error) {
 	defaultOptions := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(419430400))
-	transportCredentials := grpc.WithTransportCredentials(insecure.NewCredentials())
+	transportCredentials := grpc.WithTransportCredentials(credentials.NewTLS((&tls.Config{})))
 
 	hostConnection, err := grpc.Dial(endpoint, transportCredentials, defaultOptions)
 	if err != nil {

--- a/go/clients/diff.go
+++ b/go/clients/diff.go
@@ -5,14 +5,16 @@
 package clients
 
 import (
+	"crypto/tls"
+
 	"github.com/reviewpad/api/go/services"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 func NewDiffClient(endpoint string) (services.DiffClient, *grpc.ClientConn, error) {
 	defaultOptions := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(419430400))
-	transportCredentials := grpc.WithTransportCredentials(insecure.NewCredentials())
+	transportCredentials := grpc.WithTransportCredentials(credentials.NewTLS((&tls.Config{})))
 
 	diffConnection, err := grpc.Dial(endpoint, transportCredentials, defaultOptions)
 	if err != nil {

--- a/go/clients/robin.go
+++ b/go/clients/robin.go
@@ -5,14 +5,16 @@
 package clients
 
 import (
+	"crypto/tls"
+
 	"github.com/reviewpad/api/go/services"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 func NewRobinClient(endpoint string) (services.RobinClient, *grpc.ClientConn, error) {
 	defaultOptions := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(419430400))
-	transportCredentials := grpc.WithTransportCredentials(insecure.NewCredentials())
+	transportCredentials := grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
 
 	robinConnection, err := grpc.Dial(endpoint, transportCredentials, defaultOptions)
 	if err != nil {

--- a/go/clients/semantic.go
+++ b/go/clients/semantic.go
@@ -5,14 +5,16 @@
 package clients
 
 import (
+	"crypto/tls"
+
 	"github.com/reviewpad/api/go/services"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 func NewSemanticClient(endpoint string) (services.SemanticClient, *grpc.ClientConn, error) {
 	defaultOptions := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(419430400))
-	transportCredentials := grpc.WithTransportCredentials(insecure.NewCredentials())
+	transportCredentials := grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
 
 	semanticConnection, err := grpc.Dial(endpoint, transportCredentials, defaultOptions)
 	if err != nil {


### PR DESCRIPTION
## Description
Enables tls on grpc clients
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jul 23 07:14 UTC
This pull request adds TLS encryption to the gRPC clients in the codebase. It updates the code in the `go/clients/codehost.go`, `go/clients/diff.go`, `go/clients/robin.go`, and `go/clients/semantic.go` files to enable secure communication between the clients and the server. The patch includes changes to import the necessary TLS packages, create TLS configurations, and use them to establish a secure connection when dialing the server endpoints. Overall, this patch enhances the security of the gRPC communication between the clients and the server.
<!-- reviewpad:summarize:end -->

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge
